### PR TITLE
fix(packager): throw error when electron-prebuilt-compile is not found

### DIFF
--- a/src/util/resolve-dir.js
+++ b/src/util/resolve-dir.js
@@ -14,9 +14,13 @@ export default async (dir) => {
     if (await fs.exists(testPath)) {
       const packageJSON = JSON.parse(await fs.readFile(testPath, 'utf8'));
 
-      if (packageJSON.devDependencies && packageJSON.devDependencies['electron-prebuilt-compile']
-          && !/[0-9]/.test(packageJSON.devDependencies['electron-prebuilt-compile'][0])) {
-        global._resolveError = () => console.error('You must depend on an EXACT version of "electron-prebuilt-compile" not a range'.red);
+      if (packageJSON.devDependencies && packageJSON.devDependencies['electron-prebuilt-compile']) {
+        if (!/[0-9]/.test(packageJSON.devDependencies['electron-prebuilt-compile'][0])) {
+          global._resolveError = () => console.error('You must depend on an EXACT version of "electron-prebuilt-compile" not a range'.red);
+          return null;
+        }
+      } else {
+        global._resolveError = () => console.error('You must depend on "electron-prebuilt-compile" in your devDependencies'.red);
         return null;
       }
 


### PR DESCRIPTION
Mostly useful for existing Electron projects that want to migrate to Electron Forge.