### PR TITLE
Add support for electron-installer-debian

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "colors": "^1.1.2",
     "commander": "^2.9.0",
     "debug": "^2.3.3",
+    "electron-installer-debian": "^0.4.0",
     "electron-installer-dmg": "^0.1.2",
     "electron-packager": "^8.3.0",
     "electron-winstaller": "^2.5.0",

--- a/src/makers/darwin/dmg.js
+++ b/src/makers/darwin/dmg.js
@@ -1,16 +1,12 @@
 import electronDMG from 'electron-installer-dmg';
-import fs from 'fs-promise';
-import mkdirp from 'mkdirp';
 import path from 'path';
 import pify from 'pify';
-import rimraf from 'rimraf';
+
+import { ensureFile } from '../../util/ensure-output';
 
 export default async (dir, appName, forgeConfig) => {
   const outPath = path.resolve(dir, '../make', `${path.basename(dir)}.dmg`);
-  if (await fs.exists(outPath)) {
-    await pify(rimraf)(outPath);
-  }
-  await pify(mkdirp)(path.dirname(outPath));
+  await ensureFile(outPath);
   const dmgConfig = Object.assign({
     overwrite: true,
   }, forgeConfig.electronInstallerDMG, {

--- a/src/makers/generic/zip.js
+++ b/src/makers/generic/zip.js
@@ -1,10 +1,9 @@
 import { spawn } from 'child_process';
-import fs from 'fs-promise';
-import mkdirp from 'mkdirp';
 import path from 'path';
 import pify from 'pify';
-import rimraf from 'rimraf';
 import zipFolder from 'zip-folder';
+
+import { ensureFile } from '../../util/ensure-output';
 
 const zipPromise = (from, to) =>
   new Promise((resolve, reject) => {
@@ -21,10 +20,7 @@ const zipPromise = (from, to) =>
 
 export default async (dir, appName, forgeConfig) => { // eslint-disable-line
   const zipPath = path.resolve(dir, '../make', `${path.basename(dir)}.zip`);
-  await pify(mkdirp)(path.dirname(zipPath));
-  if (await fs.exists(zipPath)) {
-    await pify(rimraf)(zipPath);
-  }
+  await ensureFile(zipPath);
   switch (process.platform) {
     case 'win32':
       await pify(zipFolder)(dir, zipPath);

--- a/src/makers/linux/deb.js
+++ b/src/makers/linux/deb.js
@@ -1,0 +1,19 @@
+import installer from 'electron-installer-debian';
+import path from 'path';
+import pify from 'pify';
+
+import { ensureFile } from '../../util/ensure-output';
+
+export default async (dir, appName, forgeConfig) => {
+  const outPath = path.resolve(dir, '../make/debian');
+
+  await ensureFile(outPath);
+  const debianDefaults = {
+    arch: process.arch, // DOES NOT WORK WITH ARM
+    dest: outPath,
+    src: dir,
+  };
+  const debianConfig = Object.assign({}, forgeConfig.electronInstallerDebian, debianDefaults);
+
+  await pify(installer)(debianConfig);
+};

--- a/src/makers/win32/squirrel.js
+++ b/src/makers/win32/squirrel.js
@@ -1,16 +1,12 @@
 import { createWindowsInstaller } from 'electron-winstaller';
-import fs from 'fs-promise';
-import mkdirp from 'mkdirp';
 import path from 'path';
-import pify from 'pify';
-import rimraf from 'rimraf';
+
+import { ensureDirectory } from '../../util/ensure-output';
 
 export default async (dir, appName, forgeConfig) => {
   const outPath = path.resolve(dir, '../make/squirrel.windows');
-  if (await fs.exists(outPath)) {
-    await pify(rimraf)(outPath);
-  }
-  await pify(mkdirp)(outPath);
+  await ensureDirectory(outPath);
+
   const winstallerConfig = Object.assign({
     description: 'This is the default electron-forge description, you can override it in your config',
   }, forgeConfig.electronWinstallerConfig, {

--- a/src/util/ensure-output.js
+++ b/src/util/ensure-output.js
@@ -1,0 +1,21 @@
+import fs from 'fs-promise';
+import mkdirp from 'mkdirp';
+import path from 'path';
+import pify from 'pify';
+import rimraf from 'rimraf';
+
+async function ensureDirectory(dir) {
+  if (await fs.exists(dir)) {
+    await pify(rimraf)(dir);
+  }
+  return pify(mkdirp)(dir);
+}
+
+async function ensureFile(file) {
+  if (await fs.exists(file)) {
+    await pify(rimraf)(file);
+  }
+  await pify(mkdirp)(path.dirname(file));
+}
+
+export { ensureDirectory, ensureFile };

--- a/tmpl/package.json
+++ b/tmpl/package.json
@@ -2,7 +2,7 @@
   "name": "",
   "productName": "",
   "version": "1.0.0",
-  "description": "",
+  "description": "My Electron application description",
   "main": "src/index.js",
   "scripts": {
     "start": "electron-forge start"


### PR DESCRIPTION
There are two changes here:

* Create `ensure{Directory,File}` to `rimraf`+`mkdirp` the given output
* Add the debian maker

This is a PR mostly because my ES2015 code could use another pair of eyes.